### PR TITLE
[nemo-qtmultimedia-plugins] Fix initialization of properties.

### DIFF
--- a/src/videotexturebackend/videotexturebackend.cpp
+++ b/src/videotexturebackend/videotexturebackend.cpp
@@ -566,6 +566,7 @@ bool NemoVideoTextureBackend::init(QMediaService *service)
         QMetaObject::connect(
                     q, q->metaObject()->property(mirrorIndex).notifySignalIndex(),
                     this, staticMetaObject.indexOfMethod("mirrorChanged()"));
+        mirrorChanged();
     }
 
     return true;


### PR DESCRIPTION
Query the values of mirror and orientation on initialization instead
of waiting for a change notifier that may never come.
