### PR TITLE
[nemo-qtmultimedia-plugins] Ensure new nodes have valid geometry.

### DIFF
--- a/src/videotexturebackend/videotexturebackend.cpp
+++ b/src/videotexturebackend/videotexturebackend.cpp
@@ -632,6 +632,7 @@ QSGNode *NemoVideoTextureBackend::updatePaintNode(QSGNode *oldNode, QQuickItem::
 
     if (!node) {
         node = new GStreamerVideoNode(m_texture);
+        m_geometryChanged = true;
     }
 
     if (m_geometryChanged) {


### PR DESCRIPTION
Set the geometryChanged flag after creating a new node otherwise its
geometry won't be initialized unless something else coincidentally set
the flag.
